### PR TITLE
Patch - Silent error

### DIFF
--- a/client.go
+++ b/client.go
@@ -79,7 +79,10 @@ func (a *API) SendAlert(e *Event) (*Response, error) {
 
 	resp, err := http.Post(endpoint, "application/json", bytes.NewBuffer(js))
 	if err != nil {
-		fmt.Println("Error:", err)
+		return &Response{
+			Result:  "failure",
+			Message: fmt.Sprintf("Unable to send message due to: %v", err),
+		}, err
 	}
 
 	if resp.StatusCode != 200 {


### PR DESCRIPTION
If the api endpoint returns an error, it is possible for the http lib
to return a nil value causing a nil pointer exception.